### PR TITLE
Make KernelCenterer a _pairwise operation

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1584,6 +1584,10 @@ class KernelCenterer(BaseEstimator, TransformerMixin):
         K += self.K_fit_all_
 
         return K
+        
+    @property
+    def _pairwise(self):
+        return True
 
 
 def add_dummy_feature(X, value=1.0):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue

EDIT: https://github.com/scikit-learn/scikit-learn/pull/803 is the relevant PR for fixing `KernelPCA` in `Pipeline`s
#### What does this implement/fix? Explain your changes.

Allows for using `KernelCenterer` in `Pipeline`s.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Replicate solution to https://github.com/scikit-learn/scikit-learn/commit/9a520779c233dfeff466870c0b7cb04b705e61af except that `_pairwise` should always be `True` for `KernelCenterer` because it's supposed to receive a Gram matrix. This should make `KernelCenterer` usable in `Pipeline`s.

Happy to add tests, just tell me what should be covered.
